### PR TITLE
Support knex.queryBuilder() over deprecated knex()

### DIFF
--- a/src/scopes.js
+++ b/src/scopes.js
@@ -4,7 +4,8 @@ var _ = require('lodash');
 
 module.exports = function(bookshelf) {
   var baseExtend = bookshelf.Model.extend;
-  var QueryBuilder = bookshelf.knex().constructor;
+  // `bookshelf.knex()` was deprecated in knex v0.8.0, use `knex.queryBuilder()` instead if available
+  var QueryBuilder = (bookshelf.knex.queryBuilder) ? bookshelf.knex.queryBuilder().constructor : bookshelf.knex().constructor;
 
   bookshelf.Model.extend = function(protoProps) {
     var self = this;


### PR DESCRIPTION
Knex recently deprecated calling `knex()` without any arguments. Now, when you do, you get a yellow console warning:

```
Knex:warning - calling knex without a tableName is deprecated. Use knex.queryBuilder() instead.
```

This change removes the deprecated reference when queryBuilder is available for use. Once support for `knex()` is dropped completely, the check and outdated usage can be removed as well.

/cc @jtwebman 
