### PR TITLE
Set "this" to target model.prototype for relational scopes to keep consistency with standard scopes

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bookshelf-scopes",
-  "version": "1.3.0",
+  "version": "1.4.0",
   "description": "Giving you Rails like scopes in Bookshelf.js.",
   "main": "src/scopes.js",
   "dependencies": {

--- a/src/scopes.js
+++ b/src/scopes.js
@@ -64,7 +64,7 @@ module.exports = function(bookshelf) {
               relationship.relatedData.selectConstraints = function(knex, options) {
                 currentSelectConstraints.apply(this, arguments);
                 passedInArguments.unshift(knex);
-                target.prototype.scopes[key].apply(this, passedInArguments);
+                target.prototype.scopes[key].apply(target.prototype, passedInArguments);
               };
               return relationship;
             };


### PR DESCRIPTION
The "this" value was set to the prototype for standard scope usage, but the relationship for relational usage.

I've updated the relational case to set "this" to target.prototype to keep consistent behavior (it'll allow for using this.tableName in scopes regardless of whether they're used for standard or relational targets).

Test coverage has been added for the change.
