### PR TITLE
Support collection

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "bookshelf-scopes",
-  "version": "1.4.0",
+  "version": "1.5.0",
   "description": "Giving you Rails like scopes in Bookshelf.js.",
   "main": "src/scopes.js",
   "dependencies": {

--- a/src/scopes.js
+++ b/src/scopes.js
@@ -102,6 +102,7 @@ module.exports = function(bookshelf) {
     scopes: null,
 
     initialize: function() {
+      base.prototype.initialize.call(this)
       this.addScope();
     },
 

--- a/src/scopes.js
+++ b/src/scopes.js
@@ -9,7 +9,7 @@ module.exports = function(bookshelf) {
   var QueryBuilder = (bookshelf.knex.queryBuilder) ? bookshelf.knex.queryBuilder().constructor : bookshelf.knex().constructor;
 
   var extended = function(Target) {
-    if (_.isFunction(this.extended) && this.extended !== Target.extended) this.extended(Target);
+    if (_.isFunction(base.extended) && Target.extended != base.extended) base.extended(Target);
 
     Target.prototype.scopes = Target.prototype.scopes || {};
 

--- a/src/scopes.js
+++ b/src/scopes.js
@@ -10,12 +10,11 @@ var applyScope = function (_this, applier) {
     applier.call(_this, qb);
 
     // Find added statements
-    qb._statements.filter(function (statement) {
-      return !tempStatements.some(_.matches(statement));
+    _.difference(qb._statements, tempStatements)
     // Memorize scoped statements
-    }).forEach(function (statement) {
+    .forEach(function (statement) {
       _this.unscoped.scopeStatements.push(statement);
-    })
+    });
   };
 }
 

--- a/src/scopes.js
+++ b/src/scopes.js
@@ -8,15 +8,15 @@ module.exports = function(bookshelf) {
   // `bookshelf.knex()` was deprecated in knex v0.8.0, use `knex.queryBuilder()` instead if available
   var QueryBuilder = (bookshelf.knex.queryBuilder) ? bookshelf.knex.queryBuilder().constructor : bookshelf.knex().constructor;
 
-  bookshelf.Model.extend = function(protoProps, constructorProps) {
-    var model = baseExtend.apply(this, arguments);
+  var extended = function(Target) {
+    if (_.isFunction(this.extended) && this.extended !== Target.extended) this.extended(Target);
 
-    model.prototype.scopes = model.prototype.scopes || {};
+    Target.prototype.scopes = Target.prototype.scopes || {};
 
-    _.defaults(model.prototype.scopes, this.prototype.scopes || {});
+    _.defaults(Target.prototype.scopes, this.prototype.scopes || {});
 
-    Object.keys(model.prototype.scopes).forEach(function(property) {
-      model.prototype[property] = function() {
+    Object.keys(Target.prototype.scopes).forEach(function(property) {
+      Target.prototype[property] = function() {
         var _this = this;
         var passedInArguments = _.toArray(arguments);
 
@@ -32,16 +32,16 @@ module.exports = function(bookshelf) {
         }
       };
 
-      model[property] = function() {
-        var instance = model.forge();
+      Target[property] = function() {
+        var instance = Target.forge();
         return instance[property].apply(instance, arguments);
       };
     });
 
     _.each(['hasMany', 'hasOne', 'belongsToMany', 'morphOne', 'morphMany',
       'belongsTo', 'through'], function(method) {
-      var original = model.prototype[method];
-      model.prototype[method] = function() {
+      var original = Target.prototype[method];
+      Target.prototype[method] = function() {
         var relationship = original.apply(this, arguments);
         var target = relationship.model || relationship.relatedData.target;
         var originalSelectConstraints = relationship.relatedData.selectConstraints;
@@ -93,8 +93,6 @@ module.exports = function(bookshelf) {
 
       };
     });
-
-    return model;
   };
 
   var Model = bookshelf.Model.extend({
@@ -122,6 +120,9 @@ module.exports = function(bookshelf) {
       return this.resetQuery();
     }
   }, {
+
+    extended: extended,
+
     unscoped: function() {
       return this.forge().unscoped();
     }

--- a/test/scopes_collection.js
+++ b/test/scopes_collection.js
@@ -1,0 +1,246 @@
+'use strict';
+
+var expect = require('chai').expect;
+var Promise = require('bluebird');
+
+var knex = require('knex')({
+  client: 'sqlite3',
+  connection: { filename: "./mytestdb" }
+});
+
+var bookshelf = require('bookshelf')(knex);
+bookshelf.plugin(require('../src/scopes'));
+
+describe('scopes - collection', function() {
+
+  beforeEach(function() {
+    return bookshelf.knex.schema.hasTable('testmodel').then(function(exists){
+      if (exists) {
+        return bookshelf.knex.schema.dropTable('testmodel');
+      }
+    }).then(function() {
+      return bookshelf.knex.schema.createTable('testmodel', function (table) {
+        table.increments();
+        table.string('name');
+        table.string('status');
+      });
+    }).then(function () {
+      return knex('testmodel').insert([
+        {name: 'test', status: 'Active'},
+        {name: 'test1', status: 'Active'},
+        {name: 'test2', status: 'NotActive'},
+      ]);
+    });
+  });
+
+  it('can add simple scope method with a where and fetch from db', function() {
+
+    var TestModel1 = bookshelf.Model.extend({
+      tableName: 'testmodel',
+      scopes: {
+        active: function(qb) {
+          qb.where({status: 'Active'});
+        }
+      }
+    });
+
+    var TestCollection1 = bookshelf.Collection.extend({
+      model: TestModel1
+    });
+
+    expect(TestCollection1.active).to.not.be.undefined;
+    
+    return TestCollection1.active().fetch().then(function(allActive) {
+      expect(allActive.length).to.equal(2);
+      expect(allActive.models[0].get('status')).to.equal('Active');
+      expect(allActive.models[0].get('name')).to.equal('test');
+      expect(allActive.models[1].get('status')).to.equal('Active');
+      expect(allActive.models[1].get('name')).to.equal('test1');
+    });
+  });
+
+  it('can add simple scope method with a where and fetchOne from db', function() {
+
+    var TestModel1 = bookshelf.Model.extend({
+      tableName: 'testmodel',
+      scopes: {
+        active: function(qb) {
+          qb.where({status: 'Active'});
+        }
+      }
+    });
+
+    var TestCollection1 = bookshelf.Collection.extend({
+      model: TestModel1
+    });
+
+    expect(TestCollection1.active).to.not.be.undefined;
+
+    return TestCollection1.active().fetchOne().then(function(testModel) {
+      expect(testModel.get('status')).to.equal('Active');
+      expect(testModel.get('name')).to.equal('test');
+    });
+  });
+
+  it('can add combine scope methods and fetchOne from db', function() {
+
+    var TestModel1 = bookshelf.Model.extend({
+      tableName: 'testmodel',
+      scopes: {
+        active: function(qb) {
+          qb.where({status: 'Active'});
+        },
+        nameLike: function(qb, name) {
+          qb.where(knex.raw('name LIKE ?', '%' + name + '%'));
+        }
+      }
+    });
+
+    var TestCollection1 = bookshelf.Collection.extend({
+      model: TestModel1
+    });
+
+    expect(TestCollection1.active).to.not.be.undefined;
+    expect(TestCollection1.nameLike).to.not.be.undefined;
+
+    return TestCollection1.active().nameLike('1').fetchOne().then(function(testModel) {
+      expect(testModel.get('status')).to.equal('Active');
+      expect(testModel.get('name')).to.equal('test1');
+    });
+  });
+
+  it('can add combine scope methods in scope and fetch from db', function() {
+
+    var TestModel1 = bookshelf.Model.extend({
+      tableName: 'testmodel',
+      scopes: {
+        active: function(qb) {
+          qb.where({status: 'Active'});
+        },
+        nameLike: function(qb, name) {
+          qb.where(knex.raw('name LIKE ?', '%' + name + '%'));
+        },
+        activeNameLike: function(qb, name) {
+          this.active(qb)
+          this.nameLike(qb, name);
+        }
+      }
+    });
+
+    var TestCollection1 = bookshelf.Collection.extend({
+      model: TestModel1
+    });
+
+    expect(TestCollection1.active).to.not.be.undefined;
+    expect(TestCollection1.nameLike).to.not.be.undefined;
+
+    return TestCollection1.activeNameLike('1').fetch().then(function(allActive) {
+      expect(allActive.length).to.equal(1);
+      expect(allActive.models[0].get('status')).to.equal('Active');
+      expect(allActive.models[0].get('name')).to.equal('test1');
+    });
+  });
+
+  it('can add combine scope methods from base model and fetchOne from db', function() {
+
+    var TestModelBase = bookshelf.Model.extend({
+      name: 'TestModelBase',
+      scopes: {
+        active: function(qb) {
+          qb.where({status: 'Active'});
+        }
+      }
+    });
+
+    var TestModel1 = TestModelBase.extend({
+      name: 'TestModel1',
+      tableName: 'testmodel',
+      scopes: {
+        nameLike: function(qb, name) {
+          qb.where(knex.raw('name LIKE ?', '%' + name + '%'));
+        }
+      }
+    });
+
+    var TestCollection1 = bookshelf.Collection.extend({
+      model: TestModel1
+    });
+
+    expect(TestCollection1.active).to.not.be.undefined;
+    expect(TestCollection1.nameLike).to.not.be.undefined;
+
+    return TestCollection1.active().nameLike('1').fetchOne().then(function(testModel) {
+      expect(testModel.get('status')).to.equal('Active');
+      expect(testModel.get('name')).to.equal('test1');
+    });
+  });
+
+  it('no scope doesnt break existing bookshelf logic', function() {
+
+    var TestModelBase = bookshelf.Model.extend({
+      scopes: {
+        active: function(qb) {
+          qb.where({status: 'Active'});
+        }
+      }
+    });
+
+    var TestModel1 = bookshelf.Model.extend({
+      name: 'TestModel1',
+      tableName: 'testmodel',
+    });
+
+    var TestCollection1 = bookshelf.Collection.extend({
+      model: TestModel1
+    });
+
+    expect(TestCollection1.active).to.be.undefined;
+
+    return TestCollection1.forge().fetch().then(function(allModels) {
+      expect(allModels.length).to.equal(3);
+    });
+  });
+
+  it('if you set an initialize your logic gets called as well', function() {
+
+    var TestModel1 = bookshelf.Model.extend({
+      tableName: 'testmodel',
+      scopes: {
+        default: function(qb) {
+          qb.where({status: 'Active'});
+        }
+      },
+      initialize: function() {
+        this.addScope(); //Need to add scope on initialize if you are replacing it
+        this.newValue = 1;
+      }
+    });
+
+    var TestCollection1 = bookshelf.Collection.extend({
+      model: TestModel1
+    });
+
+    return TestCollection1.forge().fetch().then(function(allModels) {
+      expect(allModels.length).to.equal(2);
+      expect(allModels.models[0].newValue).to.equal(1);
+      expect(allModels.models[1].newValue).to.equal(1);
+    });
+  });
+
+  it('collection scopes should get inherited from model', function() {
+
+    var TestModel1 = bookshelf.Model.extend({
+      tableName: 'testmodel',
+      scopes: {
+        active: function(qb) {
+          qb.where({status: 'Active'});
+        }
+      }
+    });
+
+    return TestModel1.collection().active().fetch().then(function(allModels) {
+      expect(allModels.length).to.equal(2);
+    });
+  });
+
+});

--- a/test/scopes_related.js
+++ b/test/scopes_related.js
@@ -200,7 +200,7 @@ describe('scopes - related scope', function() {
       tableName: 'testmodel',
       scopes: {
         active: function(qb) {
-          if (this !== TestModel1.prototype) {
+          if (!(this instanceof bookshelf.Collection) || this.model !== TestModel1) {
             throw new Error('this not set to target prototype');
           }
 


### PR DESCRIPTION
Assign scopes straight to Collection instead of assigning them to every relation.

Fixes `Model.collection()`. Returned Collection can be scoped.

Loads of refactoring done.
